### PR TITLE
l10n hu

### DIFF
--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -1,0 +1,15 @@
+{
+    "extensionName": {
+        "message": "Címlisták kibontása",
+        "description": "Name of the extension."
+    },
+
+    "extensionDescription": {
+        "message": "A címlistákat lecseréli a címlistában szereplő címzettekre.",
+        "description": "Description of the extension."
+    },
+    "extensionButton": {
+        "message": "Címlisták kibontása",
+        "description": "Toolbar button caption."
+    }
+}


### PR DESCRIPTION
Hungarian translation

Translation to 'About this Add-on' section:

Ez a kiegészítő hozzáad egy 'Címlisták kibontása' gombot az üzenet-szerkesztő ablakhoz. Ezt a gombot megnyomva minden címlista lecserélődik a címlistában szereplő címzettekre.