### PR TITLE
Shorter l10n hu translation

### DIFF
--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -9,7 +9,7 @@
         "description": "Description of the extension."
     },
     "extensionButton": {
-        "message": "Címlisták kibontása",
+        "message": "Listák kibontása",
         "description": "Toolbar button caption."
     }
 }


### PR DESCRIPTION
I tried it, the new translation also remained clear among the testers and was 3 characters shorter. Unfortunately, most words in Hungarian are 30% longer than the same in English.